### PR TITLE
Add build property to inject compiler options

### DIFF
--- a/build/ghul.targets.targets
+++ b/build/ghul.targets.targets
@@ -17,7 +17,7 @@
 
   <Target Name="CoreCompile">
     <PropertyGroup>
-      <CommandLine>ghul-compiler --v3 @(GhulSources -> '"%(fullpath)"', '%20') -o "$(IntermediateOutputPath)$(AssemblyName).dll" @(ReferencePathWithRefAssemblies -> '-a "%(fullpath)"', '%20')</CommandLine>
+      <CommandLine>ghul-compiler $(GhulOptions) --v3 @(GhulSources -> '"%(fullpath)"', '%20') -o "$(IntermediateOutputPath)$(AssemblyName).dll" @(ReferencePathWithRefAssemblies -> '-a "%(fullpath)"', '%20')</CommandLine>
  
     </PropertyGroup>
 

--- a/ghul-targets.ghulproj
+++ b/ghul-targets.ghulproj
@@ -11,7 +11,7 @@
     <PackageId>ghul.targets</PackageId>
     <Authors>degory</Authors>
     <Company>ghul.io</Company>
-    <Version>0.0.2-alpha.1</Version>
+    <Version>0.0.2-alpha.2</Version>
 
     <PackageOutputPath>./nupkg</PackageOutputPath>
     <RepositoryUrl>https://github.com/degory/ghul-targets</RepositoryUrl>


### PR DESCRIPTION
- Add `GhulOptions` build property, which is placed on the compiler command line verbatim