### PR TITLE
Remove need to explicitly import targets and props

### DIFF
--- a/build/ghul.targets.props
+++ b/build/ghul.targets.props
@@ -1,11 +1,6 @@
 <Project>
   <PropertyGroup>
-    <GhulCompiler>ghul-compiler</GhulCompiler>
     <DebugType>None</DebugType>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="ghul.runtime" Version="*" />
-  </ItemGroup>
 </Project>

--- a/build/ghul.targets.targets
+++ b/build/ghul.targets.targets
@@ -17,8 +17,6 @@
 
   <Target Name="CoreCompile">
     <ItemGroup>
-      <VersionParameter Include="--version &quot;$(Version)&quot;" Condition="'$(Version)'!=''" />
-
       <AssemblyInfo Include="System.Reflection.AssemblyInformationalVersionAttribute" Condition="'$(Version)'!=''">
         <Parameter>$(Version)</Parameter>
       </AssemblyInfo>
@@ -50,7 +48,7 @@
         <Parameter>$(AssemblyVersion)</Parameter>
       </AssemblyInfo>
       <AssemblyInfo Include="System.Reflection.AssemblyMetadataAttribute" Condition="'$(RepositoryUrl)' != ''" >
-        <Parameter>RepositoryUrl</Parameter>
+        <Parameter>$(RepositoryUrl)</Parameter>
         <!-- TODO: common target supports multiple parameters here -->
       </AssemblyInfo>
       <AssemblyInfo Include="System.Resources.NeutralResourcesLanguageAttribute" Condition="'$(NeutralLanguage)' != ''">
@@ -62,8 +60,9 @@
     </ItemGroup>
 
     <PropertyGroup>
+      <VersionParameter Condition="'$(Version)'!=''">--version "$(Version)"</VersionParameter>
+      <GhulCompiler Condition="'$GhulCompiler'==''">ghul-compiler</GhulCompiler>
       <CommandLine>$(GhulCompiler) $(VersionParameter) $(GhulOptions) @(AssemblyInfo -> '--assembly-info-string "%(Identity)=%(Parameter)"', '%20') --v3 @(GhulSources -> '"%(fullpath)"', '%20') -o "$(IntermediateOutputPath)$(AssemblyName).dll" @(ReferencePathWithRefAssemblies -> '-a "%(fullpath)"', '%20')</CommandLine>
- 
     </PropertyGroup>
     
     <Message Importance="Low" Text="$(CommandLine)" />

--- a/ghul-targets.ghulproj
+++ b/ghul-targets.ghulproj
@@ -1,7 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="build/ghul.targets.props" />
-  <Import Project="build/ghul.targets.targets" />
-
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
 
@@ -11,7 +8,7 @@
     <PackageId>ghul.targets</PackageId>
     <Authors>degory</Authors>
     <Company>ghul.io</Company>
-    <Version>0.0.5-alpha.1</Version>
+    <Version>0.0.6-alpha.32</Version>
 
     <PackageOutputPath>./nupkg</PackageOutputPath>
 
@@ -22,15 +19,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Remove="ghul.runtime" Version="*" />
-
-    <Content Include="build\ghul.targets.targets">
+    <Content Include="build\ghul.targets.targets" PackagePath="\build">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
-    <Content Include="build\ghul.targets.props">
+    <Content Include="build\ghul.targets.props" PackagePath="\build">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
 
   <Target Name="CoreCompile" />
+  <Target Name="CreateManifestResourceNames" />
 </Project>


### PR DESCRIPTION
Enhancements:
- Targets and props files no longer need to be explicitly imported

Bugs fixed:
- GhulCompiler prop behaviour depended on target import order
- Assembly version not correctly set
- RepositoryUrl property not correctly set

Technical:
- Remove unnecessary dependency on ghul.runtime