### PR TITLE
Fixes and clean-ups

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,18 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "dotnet-setversion": {
+      "version": "2.4.0",
+      "commands": [
+        "setversion"
+      ]
+    },
+    "ghul.compiler": {
+      "version": "0.2.154",
+      "commands": [
+        "ghul-compiler"
+      ]
+    }
+  }
+}

--- a/.dependabot/ghul-targets.csproj
+++ b/.dependabot/ghul-targets.csproj
@@ -1,0 +1,3 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="../ghul-targets.ghulproj" />
+</Project>

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "nuget"
+    directory: ".dependabot/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "nuget"
+    directory: "tests/.dependabot/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -73,7 +73,9 @@ jobs:
 
     - name: Restore local .NET tools
       run: dotnet tool restore
-      working-directory: tests
+
+    - name: Set version
+      run: dotnet set-version ${{ needs.version.outputs.package }} Directory.Build.props
 
     - name: Build test project
       run: dotnet build

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -20,15 +20,15 @@ jobs:
     runs-on: ubuntu-20.04
     timeout-minutes: 1
     outputs:
-      tag: ${{ steps.pick_version.outputs.tag }}
-      package: ${{ steps.pick_version.outputs.package }}
+      tag: ${{ steps.create_version.outputs.tag }}
+      package: ${{ steps.create_version.outputs.package }}
 
     steps:
     - uses: actions/checkout@v2
 
-    - name: Pick version
-      id: bump_version
-      uses: degory/bump-version-action@v0.0.5 
+    - name: Create version
+      id: create_version
+      uses: degory/create-version@v0.0.1
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -60,7 +60,7 @@ jobs:
     runs-on: ubuntu-latest
     container: ghul/devcontainer:dotnet
     timeout-minutes: 10
-    needs: [version]
+    needs: [version,build]
 
     steps:
     - uses: actions/checkout@v2
@@ -100,7 +100,7 @@ jobs:
     runs-on: ubuntu-latest
     container: ghul/devcontainer:dotnet
     timeout-minutes: 10
-    needs: [version, test]
+    needs: [version,build,test]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -75,7 +75,7 @@ jobs:
       run: dotnet tool restore
 
     - name: Set version
-      run: dotnet set-version ${{ needs.version.outputs.package }} Directory.Build.props
+      run: dotnet setversion ${{ needs.version.outputs.package }} Directory.Build.props
 
     - name: Build test project
       run: dotnet build

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -1,4 +1,4 @@
-name: CI/CD
+name: CICD
 
 on:
   workflow_dispatch:
@@ -26,48 +26,14 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Create version number
-      id: create_version_number
-      uses: anothrNick/github-tag-action@1.33.0
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        WITH_V: true
-        DEFAULT_BUMP: patch
-        RELEASE_BRANCHES: main,master
-
     - name: Pick version
-      id: pick_version
-      run: |
-        VALID_VERSION_REGEX="^v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9]+\.[0-9]+)?$"
-        if [ ! -z "${MANUAL_VERSION}" ] ; then
-          echo "User supplied version: ${MANUAL_VERSION}"
-          VERSION="${MANUAL_VERSION}"
-        elif [ ! -z "${TAG_VERSION}" ] ; then
-          echo "Tag bump generated version: ${TAG_VERSION}"
-          VERSION="${TAG_VERSION}"
-        else
-          echo "Neither manual or tag version set"
-          exit 1
-        fi
-        if [[ ${VERSION} =~ ${VALID_VERSION_REGEX} ]] && [ "${VERSION}" != "v0.0.0" ] ; then
-          echo "Version number is valid: ${VERSION}"
-          echo "::set-output name=tag::${VERSION}"
-          echo "::set-output name=package::${VERSION:1}"
-        else
-          echo "Version number is not valid ${VERSION}"
-          exit 1
-        fi
-      env:
-        TAG_VERSION: ${{ steps.create_version_number.outputs.new_tag }}
-        MANUAL_VERSION: ${{ github.event.inputs.version }}        
-
-    - name: Echo version numbers
-      run: |
-        echo "tag version: ${{ steps.pick_version.outputs.tag }}"
-        echo "package version: ${{ steps.pick_version.outputs.package }}"
+      id: bump_version
+      uses: degory/bump-version-action@v0.0.5 
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
         
   build:
-    name: Build and publish NuGet package
+    name: Build package
     runs-on: ubuntu-latest
     container: ghul/devcontainer:dotnet
     timeout-minutes: 10
@@ -75,13 +41,72 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-                  
+
+    - name: Restore local .NET tools
+      run: dotnet tool restore
+
     - name: Create package
       run: dotnet pack -p:Version=${{ needs.version.outputs.package }}
 
     - name: Upload package artefact
       if: ${{ github.event_name != 'push' }}
       uses: actions/upload-artifact@v2
+      with:
+        name: package
+        path: nupkg
+
+  test:
+    name: Test package
+    runs-on: ubuntu-latest
+    container: ghul/devcontainer:dotnet
+    timeout-minutes: 10
+    needs: [version]
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Download package
+      uses: actions/download-artifact@v2
+      with:
+        name: package
+        path: nupkg
+
+    - name: Restore local .NET tools
+      run: dotnet tool restore
+      working-directory: tests
+
+    - name: Build test project
+      run: dotnet build
+      working-directory: tests
+
+    - name: Run test project
+      id: run
+      run: |
+        STDOUT=$(dotnet run)
+        echo "::set-output name=stdout::${STDOUT}"
+      working-directory: tests
+
+    - name: Check test output
+      run: |
+        if [ "${STDOUT}" != "Hello world!" ] ; then
+          exit 1
+        fi
+      working-directory: tests
+      env:
+        STDOUT: ${{ steps.run.outputs.stdout }}
+
+  publish-package:
+    name: Build and publish NuGet package
+    runs-on: ubuntu-latest
+    container: ghul/devcontainer:dotnet
+    timeout-minutes: 10
+    needs: [version, test]
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Download package
+      uses: actions/download-artifact@v2
       with:
         name: package
         path: nupkg
@@ -97,3 +122,43 @@ jobs:
       env:
         NUGET_TOKEN: ${{ secrets.NUGET_TOKEN }}
 
+  create_release:
+    needs: [version, publish-package]
+    name: Create release
+    runs-on: ubuntu-20.04
+
+    timeout-minutes: 5
+    if: ${{ github.event_name == 'push' }}
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Download package
+      uses: actions/download-artifact@v2
+      with:
+        name: package
+        path: nupkg
+
+    - name: Create changelog
+      run: git log -1 --format="%s%n%n%b%n%n" >changelog.txt
+
+    - name: Create a Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ needs.version.outputs.tag }}
+        release_name: ${{ needs.version.outputs.tag }}
+        body_path: changelog.txt
+        draft: false
+
+    - name: Upload package asset
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ./nupkg/ghul.targets.${{ needs.version.outputs.package }}.nupkg
+        asset_name: ghul.targets.${{ needs.version.outputs.package }}.nupkg
+        asset_content_type: application/octet-stream

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,42 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "command": "dotnet",
+            "type": "shell",
+            "args": [
+                "build",
+                // Ask dotnet build to generate full paths for file names.
+                "/property:GenerateFullPaths=true",
+                // Do not generate summary otherwise it leads to duplicate errors in Problems panel
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "group": "build",
+            "presentation": {
+                "reveal": "silent"
+            },
+            "problemMatcher": ["$ghūl", "$msCompile"]
+        },
+        {
+            "label": "pack",
+            "command": "dotnet",
+            "type": "shell",
+            "args": [
+                "pack",
+                // Ask dotnet build to generate full paths for file names.
+                "/property:GenerateFullPaths=true",
+                // Do not generate summary otherwise it leads to duplicate errors in Problems panel
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "group": "build",
+            "presentation": {
+                "reveal": "silent"
+            },
+            "problemMatcher": ["$ghūl", "$msCompile"]
+        }
+
+    ]
+}

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,5 @@
+<Project>
+    <PropertyGroup>
+        <Version>0.0.8-alpha.4</Version>
+    </PropertyGroup>
+</Project>

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 degory
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,39 @@
 # ghul-targets
-MSBuild targets for ghūl language projects
+
+[![CI/CD](https://img.shields.io/github/workflow/status/degory/ghul-targets/CICD)](https://github.com/degory/ghul-targets/actions?query=workflow%3ACICD)
+[![NuGet version (ghul.targets)](https://img.shields.io/nuget/v/ghul.targets.svg)](https://www.nuget.org/packages/ghul.targets/)
+[![Release](https://img.shields.io/github/v/release/degory/ghul-targets?label=release)](https://github.com/degory/ghul-targets/releases)
+[![Release Date](https://img.shields.io/github/release-date/degory/ghul-targets)](https://github.com/degory/ghul-targets/releases)
+[![Issues](https://img.shields.io/github/issues/degory/ghul-targets)](https://github.com/degory/ghul-targets/issues) 
+[![License](https://img.shields.io/github/license/degory/ghul-targets)](https://github.com/degory/ghul-targets/blob/main/LICENSE)
+[![ghūl](https://img.shields.io/badge/gh%C5%ABl-100%25!-information)](https://ghul.io)
+
+This package provides MSBuild targets needed to build [ghūl language](https://ghul.io) projects.
+The targets work with the standard .NET SDK targets 
+by overriding the `CoreCompile` target to call the [ghūl compiler](https://github.com/degory/ghul)
+
+This is a minimal example `.ghulproj` (ghūl project file) using the targets from this package:
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- build all files with a .ghul extension: -->
+    <GhulSources Include="**/*.ghul" />
+
+    <!-- the ghūl runtime package: -->
+    <PackageReference Include="ghul.runtime" Version="0.0.10" />
+
+    <!-- the ghūl pipes package, for the pipe operator, filter, map reduce etc.: -->
+    <PackageReference Include="ghul.pipes" Version="0.0.17" />
+
+    <!-- this package, to get the standard ghūl MSBuild targets: -->
+    <PackageReference Include="ghul.targets" Version="0.0.8" />
+  </ItemGroup>
+</Project>
+
+```

--- a/build/ghul.targets.targets
+++ b/build/ghul.targets.targets
@@ -61,7 +61,7 @@
 
     <PropertyGroup>
       <VersionParameter Condition="'$(Version)'!=''">--version "$(Version)"</VersionParameter>
-      <GhulCompiler Condition="'$GhulCompiler'==''">ghul-compiler</GhulCompiler>
+      <GhulCompiler Condition="'$(GhulCompiler)'==''">dotnet ghul-compiler</GhulCompiler>
       <CommandLine>$(GhulCompiler) $(VersionParameter) $(GhulOptions) @(AssemblyInfo -> '--assembly-info-string "%(Identity)=%(Parameter)"', '%20') --v3 @(GhulSources -> '"%(fullpath)"', '%20') -o "$(IntermediateOutputPath)$(AssemblyName).dll" @(ReferencePathWithRefAssemblies -> '-a "%(fullpath)"', '%20')</CommandLine>
     </PropertyGroup>
     

--- a/ghul-targets.ghulproj
+++ b/ghul-targets.ghulproj
@@ -4,11 +4,18 @@
 
     <Title>ghūl compiler build targets</Title>
     <PackageDescription>ghūl compiler build targets</PackageDescription>
+    <PackageTags>ghul;ghūl;compiler;msbuild;targets</PackageTags>
+    <PackageProjectUrl>https://github.com/degory/ghul-targets</PackageProjectUrl>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryUrl>https://github.com/degory/ghul-targets</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <RepositoryBranch>main</RepositoryBranch>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>    
+
     <PackageId>ghul.targets</PackageId>
     <Authors>degory</Authors>
     <Company>ghul.io</Company>
-    <Version>0.0.6-alpha.32</Version>
 
     <PackageOutputPath>./nupkg</PackageOutputPath>
 
@@ -19,6 +26,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="\"/>  
+    <None Include="LICENSE*" Pack="true" PackagePath="\" />
+
     <Content Include="build\ghul.targets.targets" PackagePath="\build">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>

--- a/tests/.dependabot/tests.csproj
+++ b/tests/.dependabot/tests.csproj
@@ -1,0 +1,3 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="../tests.ghulproj" />
+</Project>

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,19 @@
+# project specific
+*.vsix
+
+.build.rsp
+
+**/obj/
+**/bin/
+**/nupkg/
+
+.assemblies.json
+*.runtimeconfig.json
+*.exe
+*.dll
+*.pdb
+*.mdb
+**/out.txt
+**/output.txt
+
+**/out.il

--- a/tests/.vscode/tasks.json
+++ b/tests/.vscode/tasks.json
@@ -1,0 +1,24 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "command": "dotnet",
+            "type": "shell",
+            "args": [
+                "build",
+                // Ask dotnet build to generate full paths for file names.
+                "/property:GenerateFullPaths=true",
+                // Do not generate summary otherwise it leads to duplicate errors in Problems panel
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "group": "build",
+            "presentation": {
+                "reveal": "silent"
+            },
+            "problemMatcher": ["$ghūl", "$msCompile"]
+        }
+    ]
+}

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,4 @@
+# MSBuild target test project
+
+This project performs a basic test of the build targets by using them
+to compile a simple console application

--- a/tests/nuget.config
+++ b/tests/nuget.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="local" value="../nupkg" />
+  </packageSources>
+</configuration>

--- a/tests/tests.ghul
+++ b/tests/tests.ghul
@@ -1,0 +1,4 @@
+// This is a very simple ghul application: it simply writes some text to the console     
+entry() =>
+    IO.Std.out.write_line("Hello world!");
+

--- a/tests/tests.ghulproj
+++ b/tests/tests.ghulproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <GhulSources Include="**/*.ghul" />
+    <PackageReference Include="ghul.runtime" Version="0.0.10" />
+    <PackageReference Include="ghul.pipes" Version="0.0.17" />
+    <PackageReference Include="ghul.targets" Version="$(Version)" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Bugs fixed:
- GhulCompiler property default not set (closes #7)

Technical:
- Add MIT license
- Install compiler as local tool
- Add simple test that verifies the targets can be used to a build a working console app
- Update CI workflow to test targets
- Add example .ghulproj to README.md
- Add status badges to README.md
- Enable Dependabot
- Rename CI workflow to avoid issues with badge URLs