### PR TITLE
Fix CI workflow for Dependabot

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -113,6 +113,7 @@ jobs:
         path: nupkg
 
     - name: Publish package to GitHub
+      if: ${{ github.actor != 'dependabot[bot]' }}
       run: dotnet nuget push ./nupkg/*.nupkg -k ${GITHUB_TOKEN} -s https://nuget.pkg.github.com/degory/index.json --skip-duplicate --no-symbols true
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- Don't publish package to GitHub if running as Dependabot