### PR TITLE
Shorten compiler command line

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -9,7 +9,7 @@
       ]
     },
     "ghul.compiler": {
-      "version": "0.2.154",
+      "version": "0.3.3",
       "commands": [
         "ghul-compiler"
       ]

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
     <PropertyGroup>
-        <Version>0.0.11-alpha.5</Version>
+        <Version>0.0.12-alpha.1</Version>
     </PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
     <PropertyGroup>
-        <Version>0.0.10-alpha.4</Version>
+        <Version>0.0.11-alpha.5</Version>
     </PropertyGroup>
 </Project>

--- a/build/ghul.targets.targets
+++ b/build/ghul.targets.targets
@@ -62,12 +62,14 @@
     <PropertyGroup>
       <VersionParameter Condition="'$(Version)'!=''">--version "$(Version)"</VersionParameter>
       <GhulCompiler Condition="'$(GhulCompiler)'==''">dotnet ghul-compiler</GhulCompiler>
-      <CommandLine>$(GhulCompiler) $(VersionParameter) $(GhulOptions) @(GhulOptions -> '%(Identity)', ' ') @(AssemblyInfo -> '--assembly-info-string "%(Identity)=%(Parameter)"', '%20') --v3 @(GhulSources -> '"%(fullpath)"', '%20') -o "$(IntermediateOutputPath)$(AssemblyName).dll" @(ReferencePathWithRefAssemblies -> '-a "%(fullpath)"', '%20')</CommandLine>
+      <CommandLine>$(VersionParameter) $(GhulOptions) @(GhulOptions -> '%(Identity)', ' ') @(AssemblyInfo -> '--assembly-info-string "%(Identity)=%(Parameter)"', '%20') --v3 @(GhulSources -> '"%(fullpath)"', '%20') -o "$(IntermediateOutputPath)$(AssemblyName).dll" @(ReferencePathWithRefAssemblies -> '-a "%(fullpath)"', '%20')</CommandLine>
     </PropertyGroup>
     
-    <Message Importance="Low" Text="$(CommandLine)" />
-    <Exec Command="$(CommandLine)" />
+    <Message Importance="Low" Text="$(GhulCompiler) $(CommandLine)" />
 
+    <WriteLinesToFile File=".build.rsp" Lines="$(CommandLine)" Overwrite="true" Encoding="Utf-8" />
+    <Exec Command="$(GhulCompiler) @.build.rsp" />
+    <Delete Files=".build.rsp" />
     <Copy SourceFiles="$(ProjectDir)$(IntermediateOutputPath)$(AssemblyName).dll" DestinationFolder="$(ProjectDir)$(IntermediateOutputPath)ref" />   
   </Target>
 

--- a/build/ghul.targets.targets
+++ b/build/ghul.targets.targets
@@ -62,7 +62,7 @@
     <PropertyGroup>
       <VersionParameter Condition="'$(Version)'!=''">--version "$(Version)"</VersionParameter>
       <GhulCompiler Condition="'$(GhulCompiler)'==''">dotnet ghul-compiler</GhulCompiler>
-      <CommandLine>$(VersionParameter) $(GhulOptions) @(GhulOptions -> '%(Identity)', ' ') @(AssemblyInfo -> '--assembly-info-string "%(Identity)=%(Parameter)"', '%20') --v3 @(GhulSources -> '"%(fullpath)"', '%20') -o "$(IntermediateOutputPath)$(AssemblyName).dll" @(ReferencePathWithRefAssemblies -> '-a "%(fullpath)"', '%20')</CommandLine>
+      <CommandLine>$(VersionParameter) $(GhulOptions) @(GhulOptions -> '%(Identity)', '%20') @(AssemblyInfo -> '--assembly-info-string "%(Identity)=%(Parameter)"', '%20') --v3 @(GhulSources -> '"%(fullpath)"', '%20') -o "$(IntermediateOutputPath)$(AssemblyName).dll" @(ReferencePathWithRefAssemblies -> '-a "%(fullpath)"', '%20')</CommandLine>
     </PropertyGroup>
     
     <Message Importance="Low" Text="$(GhulCompiler) $(CommandLine)" />


### PR DESCRIPTION
Pass command line arguments to compiler via a file to keep the command line short, as otherwise the full command line including all source files and reference assemblies can make MSBuild output awkward to read. The full command line is retained in `.build.rsp` on errors for diagnostics purposes.