### PR TITLE
Update to .NET 8

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "dotnet-setversion": {
-      "version": "2.4.0",
+      "version": "3.0.0",
       "commands": [
         "setversion"
       ]

--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -9,7 +9,7 @@
       ]
     },
     "ghul.compiler": {
-      "version": "0.3.3",
+      "version": "0.6.4",
       "commands": [
         "ghul-compiler"
       ]

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -36,7 +36,7 @@ jobs:
     name: Build package
     runs-on: ubuntu-latest
     container:
-      image: mcr.microsoft.com/dotnet/sdk:6.0-focal
+      image: mcr.microsoft.com/dotnet/sdk:8.0-jammy
 
     timeout-minutes: 10
     needs: [version]
@@ -60,7 +60,7 @@ jobs:
     name: Test package
     runs-on: ubuntu-latest
     container:
-      image: mcr.microsoft.com/dotnet/sdk:6.0-focal
+      image: mcr.microsoft.com/dotnet/sdk:8.0-jammy
 
     timeout-minutes: 10
     needs: [version,build]
@@ -104,7 +104,7 @@ jobs:
     name: Publish NuGet package
     runs-on: ubuntu-latest
     container:
-      image: mcr.microsoft.com/dotnet/sdk:6.0-focal
+      image: mcr.microsoft.com/dotnet/sdk:8.0-jammy
 
     timeout-minutes: 10
     needs: [version,build,test]

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -15,23 +15,30 @@ env:
   CI: true
 
 jobs:
-  version:
+ version:
     name: Create a version number
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     timeout-minutes: 1
     outputs:
       tag: ${{ steps.create_version.outputs.tag }}
       package: ${{ steps.create_version.outputs.package }}
+      
+    permissions:
+      contents: 'write'
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: '0'    
 
     - name: Create version
       id: create_version
-      uses: degory/create-version@v0.0.1
+      uses: degory/create-version@v0.0.2
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
-        
+      env:
+        PRERELEASE: ${{ github.event_name == 'pull_request' }}
+
   build:
     name: Build package
     runs-on: ubuntu-latest

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -15,7 +15,7 @@ env:
   CI: true
 
 jobs:
- version:
+  version:
     name: Create a version number
     runs-on: ubuntu-latest
     timeout-minutes: 1

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -84,9 +84,6 @@ jobs:
     - name: Restore local .NET tools
       run: dotnet tool restore
 
-    - name: Set version
-      run: dotnet setversion ${{ needs.version.outputs.package }} Directory.Build.props
-
     - name: Build test project
       run: dotnet build
       working-directory: tests

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -84,6 +84,9 @@ jobs:
     - name: Restore local .NET tools
       run: dotnet tool restore
 
+    - name: Set version
+      run: dotnet setversion ${{ needs.version.outputs.package }} Directory.Build.props
+
     - name: Build test project
       run: dotnet build
       working-directory: tests

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
     <PropertyGroup>
-        <Version>1.2.0-alpha.2</Version>
+        <Version>1.3.0-alpha.2</Version>
     </PropertyGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
 [![Release Date](https://img.shields.io/github/release-date/degory/ghul-targets)](https://github.com/degory/ghul-targets/releases)
 [![Issues](https://img.shields.io/github/issues/degory/ghul-targets)](https://github.com/degory/ghul-targets/issues) 
 [![License](https://img.shields.io/github/license/degory/ghul-targets)](https://github.com/degory/ghul-targets/blob/main/LICENSE)
-[![ghūl](https://img.shields.io/badge/gh%C5%ABl-100%25!-information)](https://ghul.io)
+[![ghūl](https://img.shields.io/badge/gh%C5%ABl-100%25!-information)](https://ghul.dev)
 
-This package provides MSBuild targets needed to build [ghūl language](https://ghul.io) projects.
+This package provides MSBuild targets needed to build [ghūl language](https://ghul.dev) projects.
 The targets work with the standard .NET SDK targets 
 by overriding the `CoreCompile` target to call the [ghūl compiler](https://github.com/degory/ghul)
 
@@ -18,7 +18,7 @@ This is a minimal example `.ghulproj` (ghūl project file) using the targets fro
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>    
@@ -27,7 +27,7 @@ This is a minimal example `.ghulproj` (ghūl project file) using the targets fro
     
     <PackageReference Include="ghul.runtime" Version="1.0.0" /> <!-- ghūl runtime library -->
     <PackageReference Include="ghul.pipes" Version="1.0.0" /> <!-- ghūl pipes provides the pipe operator, filter, map reduce etc. -->
-    <PackageReference Include="ghul.targets" Version="1.0.1" /> <!-- this package provides ghūl MSBuild targets: -->
+    <PackageReference Include="ghul.targets" Version="1.3.0" /> <!-- this package provides ghūl MSBuild targets: -->
   </ItemGroup>
 </Project>
 

--- a/ghul-targets.ghulproj
+++ b/ghul-targets.ghulproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <Title>ghūl compiler build targets</Title>
     <PackageDescription>ghūl compiler build targets</PackageDescription>
@@ -15,7 +15,7 @@
 
     <PackageId>ghul.targets</PackageId>
     <Authors>degory</Authors>
-    <Company>ghul.io</Company>
+    <Company>ghul.dev</Company>
 
     <PackageOutputPath>./nupkg</PackageOutputPath>
 

--- a/tests/tests.ghulproj
+++ b/tests/tests.ghulproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <GhulOptions>--define ghul</GhulOptions>
   </PropertyGroup>


### PR DESCRIPTION
- Bump TargetFramework to 'net8.0' in .ghulproj
- Update CI/CD pipeline to run on .NET 8 and Ubuntu 22.04
- Update project website property to point at https://ghul.dev
- Reference latest version of compiler tool