### PR TITLE
Fix broken URL in project file

### DIFF
--- a/ghul-targets.ghulproj
+++ b/ghul-targets.ghulproj
@@ -5,7 +5,7 @@
     <Title>ghūl compiler build targets</Title>
     <PackageDescription>ghūl compiler build targets</PackageDescription>
     <PackageTags>ghul;ghūl;compiler;msbuild;targets</PackageTags>
-    <PackageProjectUrl>https://github.com/degory/ghul-targets</PackageProjectUrl>
+    <PackageProjectUrl>https://ghul.dev</PackageProjectUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryUrl>https://github.com/degory/ghul-targets</RepositoryUrl>


### PR DESCRIPTION
- Fix package project URL to point at https://ghul.dev